### PR TITLE
Revert mps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ---
 
 | <img src="https://raw.githubusercontent.com/yutanagano/sceptr/main/docs/graphical_abstract.png" width=700> |
-|---|
+|-|
 | Graphical abstract. Traditional protein language models that are trained purely on masked-language modelling underperform sequence alignment models on TCR specificity prediction. In contrast, our model SCEPTR is jointly trained on masked-language modelling and contrastive learning, allowing it to outperform other language models as well as the best sequence alignment models to achieve state-of-the-art performance. |
 
 **SCEPTR** (**S**imple **C**ontrastive **E**mbedding of the **P**rimary sequence of **T** cell **R**eceptors) is a small, fast, and informative TCR representation model that can be used for alignment-free TCR  analysis, including for TCR-pMHC interaction prediction and TCR clustering (metaclonotype discovery).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Our `manuscript <https://www.cell.com/cell-systems/fulltext/S2405-4712(24)00369-
 
 SCEPTR is a BERT-like transformer-based neural network implemented in `Pytorch <https://pytorch.org>`_.
 With the default model providing best-in-class performance with only 153,108 parameters (typical protein language models have tens or hundreds of millions), SCEPTR runs fast- even on a CPU!
-And if your computer does have a `CUDA- <https://developer.nvidia.com/cuda-zone>`_ or `MPS-enabled <https://developer.apple.com/documentation/metalperformanceshaders>`_ GPU, the sceptr package will automatically detect and use it, giving you blazingly fast performance without the hassle.
+And if your computer does have a `CUDA-enabled <https://developer.nvidia.com/cuda-zone>`_ GPU, the sceptr package will automatically detect and use it, giving you blazingly fast performance without the hassle.
 
 sceptr's :ref:`API <api>` exposes four intuitive functions: :py:func:`~sceptr.calc_cdist_matrix`, :py:func:`~sceptr.calc_pdist_vector`, :py:func:`~sceptr.calc_vector_representations`, and :py:func:`~sceptr.calc_residue_representations` -- and it's all you need to make full use of the SCEPTR models.
 What's even better is that they are fully compliant with `pyrepseq <https://pyrepseq.readthedocs.io>`_'s `tcr_metric <https://pyrepseq.readthedocs.io/en/latest/api.html#pyrepseq.metric.tcr_metric.TcrMetric>`_ API, so sceptr will fit snugly into the rest of your repertoire analysis toolkit.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -96,7 +96,7 @@ Hardware acceleration / device selection
 ----------------------------------------
 
 By default, SCEPTR will detect any available devices with harware-acceleration capabilities and automatically load models onto those devices.
-`CUDA- <https://developer.nvidia.com/cuda-zone>`_ and `MPS-enabled <https://developer.apple.com/documentation/metalperformanceshaders>`_ devices are supported.
+Currently, `CUDA-enabled <https://developer.nvidia.com/cuda-zone>`_ devices are supported, with MPS pending on `better upstream Pytorch support <https://github.com/pytorch/pytorch/issues/77764>`_.
 In cases where you would like to explicitly limit SCEPTR to using the CPU, you can call :py:func:`sceptr.disable_hardware_acceleration`.
 
 .. _data_format:

--- a/src/sceptr/__init__.py
+++ b/src/sceptr/__init__.py
@@ -100,7 +100,7 @@ def calc_residue_representations(instances: DataFrame) -> ResidueRepresentations
 
 def enable_hardware_acceleration() -> None:
     """
-    Instruct SCEPTR to detect and use available hardware acceleration, such as CUDA or MPS.
+    Instruct SCEPTR to detect and use available hardware acceleration, such as CUDA.
 
     While hardware acceleration is toggled on by default, it can be turned off manually by calling :py:func:`sceptr.disable_hardware_acceleration`.
     This function allows you to turn the setting back on.
@@ -121,7 +121,7 @@ def disable_hardware_acceleration() -> None:
     """
     Instruct SCEPTR to ignore hardware acceleration options and only use the CPU.
 
-    By default, SCEPTR will look for available hardware acceleration devices such as CUDA- or MPS-enabled GPUs and perform computations there.
+    By default, SCEPTR will look for available hardware acceleration devices such as CUDA-enabled GPUs and perform computations there.
     However, in some cases it may be favourable to explicitly keep models on the CPU (e.g. a CUDA-enabled GPU is available but does not have sufficient VRAM for your use case).
     This function is useful for such scenarios.
     This setting can be reversed using :py:func:`sceptr.enable_hardware_acceleration`.

--- a/src/sceptr/model.py
+++ b/src/sceptr/model.py
@@ -137,7 +137,7 @@ class Sceptr:
 
     def enable_hardware_acceleration(self) -> None:
         """
-        Move this `Sceptr` instance and its computations to a hardware-accelerated device, if available (e.g. CUDA- or MPS-enabled GPU).
+        Move this `Sceptr` instance and its computations to a hardware-accelerated device, if available (e.g. CUDA-enabled GPU).
         For toggling the package-level setting, see :py:func:`sceptr.enable_hardware_acceleration`.
         """
         self._device = _get_hardware_accelerated_device()

--- a/src/sceptr/model.py
+++ b/src/sceptr/model.py
@@ -324,7 +324,8 @@ def _get_hardware_accelerated_device() -> torch.device:
     if torch.cuda.is_available():
         return torch.device("cuda")
 
-    if torch.mps.is_available():
-        return torch.device("mps")
+    # Below is commented out for now until MPS support is more stable / complete
+    # if torch.mps.is_available():
+    #     return torch.device("mps")
 
     return torch.device("cpu")


### PR DESCRIPTION
* After adding experimental MPS support, discovered that not all transformer operations are fully supported on MPS currently
* Reverted MPS support as current user experience with it is bad
* Re-introduction of MPS support pending better upstream Pytorch support